### PR TITLE
Removed cross_compile from Eloquent and Dashing released packages list.

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -24,7 +24,6 @@ const latest_packages = {
 };
 
 const dashing_packages = {
-  "cross_compile": {},
   "ros2bag": {'no_dev_build': true},
   "rosbag2": {},
   "rosbag2_converter_default_plugins": {'no_dev_build': true},
@@ -40,7 +39,6 @@ const dashing_packages = {
 };
 
 const eloquent_packages = {
-  "cross_compile": {},
   "ros2bag": {'no_dev_build': true},
   "rosbag2": {},
   "rosbag2_converter_default_plugins": {'no_dev_build': true},


### PR DESCRIPTION
Signed-off-by: Jaison Titus <jaisontj@amazon.com>

Running locally: 

<img width="1441" alt="Screen Shot 2020-10-19 at 4 38 22 PM" src="https://user-images.githubusercontent.com/13097323/96523461-a587d100-122a-11eb-8eb1-44ad6ea6c311.png">
